### PR TITLE
Show_fixed_source:显示修正后的源码

### DIFF
--- a/zh_CN/messages.json
+++ b/zh_CN/messages.json
@@ -299,7 +299,7 @@
         "message": "脚本调试"
     },
     "Show_fixed_source": {
-        "message": "显示规格化的源码"
+        "message": "显示修正后的源码"
     },
     "LogLevel": {
         "message": "日志记录级别"


### PR DESCRIPTION
Improve translation.

规格化 is not good, change to 修正后.

按照https://forum.tampermonkey.net/viewtopic.php?t=316#p1638 Show_fixed_source是修正以前不兼容的代码，所以用“修正后”更好。