### PR TITLE
sr/messages.json: Fix typo in "Restart_Tampermonkey" message

### DIFF
--- a/sr/messages.json
+++ b/sr/messages.json
@@ -945,7 +945,7 @@
         "message": "Resursi"
     },
     "Restart_Tampermonkey": {
-        "message": "Restart-uj Tampermonkey"
+        "message": "Restartuj Tampermonkey"
     },
     "Run_at": {
         "message": "Pokreni u"


### PR DESCRIPTION
Remove - from message, so it is "Restartuj" no "Restart-uj"