### PR TITLE
Update Chinese Simplified Translation

### DIFF
--- a/zh_CN/messages.json
+++ b/zh_CN/messages.json
@@ -141,7 +141,7 @@
         "message": "添加新脚本..."
     },
     "Add_toSource_function_to_Object_Prototype": {
-        "message": "为对象和数组增加兼容性函数"
+        "message": "为对象和数组增加兼容性方法"
     },
     "Advanced": {
         "message": "高级"
@@ -378,7 +378,7 @@
         "message": "关闭"
     },
     "Closing_Bracket": {
-        "message": "关闭括号"
+        "message": "配对括号"
     },
     "Cloud": {
         "message": "云"
@@ -423,7 +423,7 @@
         "message": "调试"
     },
     "Debug_scripts": {
-        "message": "脚本调试"
+        "message": "调试脚本"
     },
     "Default": {
         "message": "默认"
@@ -759,7 +759,7 @@
         "message": "包括/排除"
     },
     "Incremental_Find": {
-        "message": "增亮查找"
+        "message": "增量查找"
     },
     "Indent": {
         "message": "缩进"
@@ -840,7 +840,7 @@
         "message": "受限的运行时主机权限可能损坏脚本升级、 GM_xmlhttpRequest 以及其他 Tampermonkey 功能！"
     },
     "Line_Case_Insensitive": {
-        "message": "行大小写不敏感"
+        "message": "按行的忽略大小写的字典序"
     },
     "Line_Down": {
         "message": "下一行"
@@ -852,7 +852,7 @@
         "message": "自动换行"
     },
     "Lines": {
-        "message": "行"
+        "message": "按行的字典序"
     },
     "LogLevel": {
         "message": "日志记录级别"
@@ -879,10 +879,10 @@
         "message": "修改"
     },
     "Move_Line_Down": {
-        "message": "行下移"
+        "message": "下移行"
     },
     "Move_Line_Up": {
-        "message": "行上移"
+        "message": "上移行"
     },
     "Name": {
         "message": "名称"
@@ -1184,16 +1184,16 @@
         "message": "选择下一个出现位置"
     },
     "Select_Scope": {
-        "message": "选择范围"
+        "message": "选择块"
     },
     "Select_between_Brackets": {
-        "message": "选择括号间"
+        "message": "选择前后括号中间的部分"
     },
     "Select_to_Sublime_Mark": {
         "message": "选择到 Sublime 标记"
     },
     "Selection": {
-        "message": "选择内容"
+        "message": "选择"
     },
     "Server_And_Manual": {
         "message": "远程 + 手动管理"
@@ -1458,16 +1458,16 @@
         "message": "切换"
     },
     "Toggle_Block_Comment": {
-        "message": "切换块注释"
+        "message": "添加/移除块注释"
     },
     "Toggle_Comment": {
-        "message": "切换注释"
+        "message": "添加/移除注释"
     },
     "Toggle_Comment_Indented": {
-        "message": "切换缩进注释"
+        "message": "添加/移除缩进注释"
     },
     "Toggle_Enable": {
-        "message": "切换启用/禁用"
+        "message": "启用/禁用"
     },
     "Trace": {
         "message": "追踪"

--- a/zh_CN/messages.json
+++ b/zh_CN/messages.json
@@ -699,10 +699,10 @@
         "message": "Google Drive"
     },
     "Group_Left": {
-        "message": "分组左侧"
+        "message": "单词左侧"
     },
     "Group_Right": {
-        "message": "分组右侧"
+        "message": "单词右侧"
     },
     "Help": {
         "message": "帮助"


### PR DESCRIPTION
"function" is usually translated as "方法" in formal documents when it means a method in an object (or a class).
"closing bracket" here means the bracket that matches the current one so it should be translated as "配对括号" instead of "关闭括号" which means "close the bracket".
"debug script" should be "调试脚本". The current one has wrong word order. 
Add extra information to "Line_Case_Insensitive" and "Lines" to help users understand.
"move line down" should be "下移行". The current one has wrong word order. 
"move line up" should be "上移行". The current one has wrong word order.
"save to disk" is not modified. Actually the function of this button is to save the script to local file system instead of disk. However the English translation said "disk".
"scope" is widely translated as "块" when it means the texts between "{" and "}". (Actually there is no other widely-spreaded translation)
"select between brackets" is changed to "选择前后括号中间的部分" because the current one "选择括号间" is strange.
"selection" should be "选择" instead of "选择内容" which means "select content".
"toggle" here means to add or remove something, not to switch.
"incremental" means "增量" instead of "增亮".