### PR TITLE
Fix the Chinese(Simplified) translation mistake for "Lines"

### DIFF
--- a/zh_CN/messages.json
+++ b/zh_CN/messages.json
@@ -840,7 +840,7 @@
         "message": "受限的运行时主机权限可能损坏脚本升级、 GM_xmlhttpRequest 以及其他 Tampermonkey 功能！"
     },
     "Line_Case_Insensitive": {
-        "message": "按行的忽略大小写的字典序"
+        "message": "忽略大小写的行"
     },
     "Line_Down": {
         "message": "下一行"
@@ -852,7 +852,7 @@
         "message": "自动换行"
     },
     "Lines": {
-        "message": "按行的字典序"
+        "message": "行"
     },
     "LogLevel": {
         "message": "日志记录级别"


### PR DESCRIPTION
In the previous pull request I changed "行" to "按行的字典序" because "按行的字典序" seems better at (2) in the following image.
However later I found the string is also used at (1), which makes it a bad idea to use "按行的字典序".
So I thought over and changed the translation again.
Sorry for the mistake.
![2021-04-02 17-35-03 创建的截图](https://user-images.githubusercontent.com/51874645/113404636-1129b900-93db-11eb-85b8-4dd3c17ec1c0.png)

@xiaopangju @derjanb 